### PR TITLE
MARBLE-1068 Rewrite Lambda as function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 .aws
 .aws-sam
+coverage
 deploy.yaml
 node_modules
 package-lock.json
 samconfig.toml
+yarn.lock

--- a/dependencies/nodejs/package.json
+++ b/dependencies/nodejs/package.json
@@ -1,12 +1,11 @@
 {
   "name": "serverless-iiif-dependencies",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Dependencies for serverless IIIF",
   "author": "Michael B. Klein",
   "license": "Apache-2.0",
   "dependencies": {
     "aws-sdk": "^2.368.0",
-    "iiif-processor": "~0.3.1",
-    "middy": "^0.19.4"
+    "iiif-processor": "~0.3.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "serverless-iiif",
+  "version": "2.0.0",
+  "description": "Lambda wrapper for iiif-processor",
+  "author": "Michael B. Klein",
+  "license": "Apache-2.0",
+  "dependencies": {},
+  "devDependencies": {
+    "aws-sdk": "^2.368.0",
+    "iiif-processor": "~0.3.1",
+    "jest": "^26.4.2"
+  },
+  "jest": {
+    "collectCoverageFrom": [
+      "src/**/*.js"
+    ],
+    "testPathIgnorePatterns": [
+      "<rootDir>[/\\\\](build|docs|node_modules|scripts)[/\\\\]"
+    ],
+    "testEnvironment": "node",
+    "moduleDirectories": [
+      "node_modules"
+    ]
+  },
+  "scripts": {
+    "test": "node scripts/test.js --env=jsdom"
+  }
+}

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -1,0 +1,14 @@
+'use strict';
+
+process.env.tiffBucket = 'test-bucket';
+
+const jest = require('jest');
+const argv = process.argv.slice(2);
+
+// Watch unless on CI or in coverage mode
+if (!process.env.CI && argv.indexOf('--coverage') < 0) {
+  argv.push('--watch');
+}
+
+
+jest.run(argv);

--- a/src/error.js
+++ b/src/error.js
@@ -1,0 +1,24 @@
+const errorHandler = async (err, event, context, resource, callback) => {
+  console.error(err);
+  console.log('this.event = ', event);
+  console.log('this.context = ', context);
+  if (err.statusCode) {
+    return await callback(null, {
+      statusCode: err.statusCode,
+      headers: { 'Content-Type': 'text/plain' },
+      body: 'Not Found'
+    });
+  } else if (err instanceof resource.errorClass) {
+    return await callback(null, {
+      statusCode: 400,
+      headers: { 'Content-Type': 'text/plain' },
+      body: err.toString()
+    });
+  } else {
+    return await callback(err, null);
+  }
+};
+
+module.exports = {
+  errorHandler: errorHandler,
+}

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,0 +1,49 @@
+const eventPath = (event) => {
+  if (includeStage(event)) {
+    const path = '/' + event.requestContext.stage + event.path;
+    return path.replace(/\/*$/, '');
+  }
+  return event.path.replace(/\/*$/, '');
+};
+
+const fileMissing = (event) => {
+  return !/\.(jpg|tif|gif|png|json)$/.test(event.path);
+};
+
+const getUri = (event) => {
+  const scheme = event.headers['X-Forwarded-Proto'] || 'http';
+  const host = event.headers['X-Forwarded-Host'] || event.headers['Host'];
+  const uri = `${scheme}://${host}${eventPath(event)}`;
+  console.log('iiif image uri = ', uri);
+  return uri;
+};
+
+const includeStage = (event) => {
+  if ('include_stage' in process.env) {
+    return ['true', 'yes'].indexOf(process.env.include_stage.toLowerCase()) > -1;
+  } else {
+    const host = event.headers['Host'];
+    return host.match(/\.execute-api\.\w+?-\w+?-\d+?\.amazonaws\.com$/);
+  }
+};
+
+const isBase64 = (result) => {
+  return /^image\//.test(result.contentType);
+};
+
+const isTooLarge = (content) => {
+  return content.length > 6 * 1024 * 1024;
+}
+const getRegion = (context) => {
+  return context.invokedFunctionArn.match(/^arn:aws:lambda:(\w+-\w+-\d+):/)[1];
+}
+
+module.exports = {
+  eventPath: eventPath,
+  fileMissing: fileMissing,
+  getUri: getUri,
+  includeStage: includeStage,
+  isBase64: isBase64,
+  isTooLarge: isTooLarge,
+  getRegion: getRegion,
+};

--- a/src/index.js
+++ b/src/index.js
@@ -6,174 +6,60 @@
 
 const AWS = require('aws-sdk');
 const IIIF = require('iiif-processor');
-const middy = require('middy');
-const { cors, httpHeaderNormalizer } = require('middy/middlewares');
+const helpers = require('./helpers')
+const resolvers = require('./resolvers');
+const errorHandler = require('./error')
 
-const handleRequest = (event, context, callback) => {
-  try {
-    new IIIFLambda(event, context, callback, process.env.tiffBucket)
-      .processRequest();
-  } catch (err) {
-    callback(err, null);
+const handleRequestFunc = async (event, context, callback) => {
+  const { eventPath, fileMissing, getUri, isBase64, isTooLarge, getRegion } = helpers;
+  const { streamResolver, dimensionResolver } = resolvers;
+  AWS.config.region = getRegion(context);
+
+  // OPTIONS REQUEST
+  if (event.httpMethod === 'OPTIONS') {
+    console.log('OPTIONS REQUEST');
+    return await callback(null, { statusCode: 204, body: null });
+  }
+  // INFO.JSON REQUEST
+  else if (fileMissing(event)) {
+    const location = eventPath(event) + '/info.json';
+    console.log(`INFO.JSON REQUEST: ${location}`);
+    return await callback(null, { statusCode: 302, headers: { 'Location': location }, body: 'Redirecting to info.json' });
+  }
+  // IMAGE REQUEST
+  else {
+    const uri = getUri(event);
+    const resource = new IIIF.Processor(
+      uri,
+      streamResolver,
+      dimensionResolver
+    );
+    const result = await resource.execute();
+    try {
+      const base64 = isBase64(result);
+      const content = base64 ? result.body.toString('base64') : result.body;
+      const response = {
+        statusCode: 200,
+        headers: {
+          'Content-Type': result.contentType,
+          'Access-Control-Allow-Origin': '*'
+         },
+        isBase64Encoded: base64,
+        body: content
+      };
+      if (isTooLarge(content)) {
+        const uri = getUri(event);
+        console.log(`base64.length = ${content.length}, original.length =  ${result.body.length}`);
+        throw Error (`Content size (${content.length.toString()}) exceeds API gateway maximum when calling ${uri}`);
+      } else {
+        return await callback(null, response);
+      }
+    } catch (err) {
+      return errorHandler.errorHandler(err, event, context, resource, callback);
+    }
   }
 };
 
-class IIIFLambda {
-  constructor (event, context, callback, sourceBucket) {
-    this.event = event;
-    this.context = context;
-    this.respond = callback;
-    this.sourceBucket = sourceBucket;
-    this.handled = false;
-    // console.log("IIIFLambda.constructor called with sourceBucket", sourceBucket)
-  }
-
-  directResponse (result) {
-    var base64 = /^image\//.test(result.contentType);
-    var content = base64 ? result.body.toString('base64') : result.body;
-    var response = {
-      statusCode: 200,
-      headers: {
-        'Content-Type': result.contentType,
-        'Access-Control-Allow-Origin': '*'
-       },
-      isBase64Encoded: base64,
-      body: content
-    };
-    if (content.length > 6 * 1024 * 1024) {
-        var scheme = this.event.headers['X-Forwarded-Proto'] || 'http';
-        var host = this.event.headers['Host'];
-        var uri = `${scheme}://${host}${this.eventPath()}`;
-        console.log("base64.length = ", content.length, "original.length = ", result.body.length)
-        throw Error ('Content size (' + content.length.toString() + ') exceeds API gateway maximum when calling ' + uri)
-    } else {
-        this.respond(null, response);
-    }
-  }
-
-  handleError (err, _resource) {
-    console.error(err)
-    console.log("this.event = ", this.event)
-    console.log("this.context = ", this.context)
-    if (err.statusCode) {
-      this.respond(null, {
-        statusCode: err.statusCode,
-        headers: { 'Content-Type': 'text/plain' },
-        body: 'Not Found'
-      });
-    } else if (err instanceof this.resource.errorClass) {
-      this.respond(null, {
-        statusCode: 400,
-        headers: { 'Content-Type': 'text/plain' },
-        body: err.toString()
-      });
-    } else {
-      this.respond(err, null);
-    }
-  }
-
-  includeStage() {
-    if ('include_stage' in process.env) {
-      return ['true', 'yes'].indexOf(process.env.include_stage.toLowerCase()) > -1;
-    } else {
-      var host = this.event.headers['Host'];
-      return host.match(/\.execute-api\.\w+?-\w+?-\d+?\.amazonaws\.com$/);
-    }
-  }
-
-  fileMissing() {
-    return !/\.(jpg|tif|gif|png|json)$/.test(this.event.path);
-  }
-
-  eventPath() {
-    if ('storedEventPath' in this) return this.storedEventPath;
-
-    var path = this.event.path;
-    if (this.includeStage()) {
-      path = '/' + this.event.requestContext.stage + path;
-    }
-    this.storedEventPath = path.replace(/\/*$/, '');
-    return this.storedEventPath;
-  }
-
-  checkForOptionsRequest() {
-    if (this.handled) return this;
-    if (this.event.httpMethod === 'OPTIONS') {
-      this.respond(null, { statusCode: 204, body: null });
-      this.handled = true;
-    }
-    return this;
-  }
-
-  checkForInfoJsonRedirect() {
-    if (this.handled) return this;
-    if (this.fileMissing()) {
-      console.log("file is missing, redirect to info.json")
-      var location = this.eventPath() + '/info.json';
-      this.respond(null, { statusCode: 302, headers: { 'Location': location }, body: "Redirecting to info.json" });
-      this.handled = true;
-    }
-    return this;
-  }
-
-  execute() {
-    if (this.handled) return this;
-
-    var scheme = this.event.headers['X-Forwarded-Proto'] || 'http';
-    var host = this.event.headers['X-Forwarded-Host'] || this.event.headers['Host'];
-    var uri = `${scheme}://${host}${this.eventPath()}`;
-    console.log("iiif image uri = ", uri)
-
-    this.resource = new IIIF.Processor(
-      uri, 
-      (id) => { return this.s3Object(id) }, 
-      (id) => { return this.dimensions(id, this.sourceBucket) }
-    );
-
-    this.resource
-      .execute()
-      .then(result => this.directResponse(result))
-      .catch(err => this.handleError(err));
-
-    this.handled = true;
-    return this;
-  }
-
-  processRequest () {
-    AWS.config.region = this.context.invokedFunctionArn.match(/^arn:aws:lambda:(\w+-\w+-\d+):/)[1];
-
-    this
-      .checkForOptionsRequest()
-      .checkForInfoJsonRedirect()
-      .execute()
-  }
-
-  async dimensions (id, bucket) {
-    var s3 = new AWS.S3();
-    const obj = await s3.headObject({
-      Bucket: bucket,
-      Key: `${id}.tif`
-    }).promise()
-    if (obj.Metadata.width && obj.Metadata.height) {
-      return {
-        width: parseInt(obj.Metadata.width, 10),
-        height: parseInt(obj.Metadata.height, 10)
-      }
-    }
-    return null;
-  }
-
-  s3Object (id) {
-    var s3 = new AWS.S3();
-    return s3.getObject({
-      Bucket: this.sourceBucket,
-      Key: `${id}.tif`
-    }).createReadStream();
-  }
-}
-
 module.exports = {
-  handler: middy(handleRequest)
-    .use(httpHeaderNormalizer())
-    .use(cors())
+  handler: handleRequestFunc,
 };

--- a/src/package.json
+++ b/src/package.json
@@ -1,13 +1,12 @@
 {
   "name": "serverless-iiif",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Lambda wrapper for iiif-processor",
   "author": "Michael B. Klein",
   "license": "Apache-2.0",
   "dependencies": {},
   "devDependencies": {
     "aws-sdk": "^2.368.0",
-    "iiif-processor": "~0.3.1",
-    "middy": "^0.19.4"
+    "iiif-processor": "~0.3.1"
   }
 }

--- a/src/resolvers.js
+++ b/src/resolvers.js
@@ -1,0 +1,36 @@
+const AWS = require('aws-sdk');
+const sourceBucket = process.env.tiffBucket;
+
+// IIIF RESOLVERS
+const streamResolver = async (id, callback) => {
+  const s3 = new AWS.S3();
+  const key = id + '.tif';
+  const request = s3.getObject({ Bucket: sourceBucket, Key: key });
+  const stream = request.createReadStream();
+  try {
+    return await callback(stream);
+  } finally {
+    stream.end().destroy();
+    request.abort();
+  }
+};
+
+const dimensionResolver = async (id) => {
+  const s3 = new AWS.S3();
+  const obj = await s3.headObject({
+    Bucket: sourceBucket,
+    Key: `${id}.tif`
+  }).promise();
+  if (obj.Metadata.width && obj.Metadata.height) {
+    return {
+      width: parseInt(obj.Metadata.width, 10),
+      height: parseInt(obj.Metadata.height, 10)
+    };
+  }
+  return null;
+};
+
+module.exports = {
+  streamResolver: streamResolver,
+  dimensionResolver: dimensionResolver,
+}

--- a/tests/__mocks/mockResource.js
+++ b/tests/__mocks/mockResource.js
@@ -1,0 +1,12 @@
+class errorClass {
+  constructor(err) {
+    this.err = err
+  }
+  toString() {
+    return this.err
+  }
+}
+
+module.exports = {
+  errorClass: errorClass,
+}

--- a/tests/__mocks/mockS3.js
+++ b/tests/__mocks/mockS3.js
@@ -1,0 +1,41 @@
+const destroy = jest.fn();
+const end = jest.fn(() => {
+  return {
+    destroy: destroy
+  };
+});
+const abort = jest.fn();
+const S3 = jest.fn().mockImplementation(() => {
+  return {
+    getObject: function(params) {
+      return {
+        createReadStream: () => {
+          return {
+            end: end
+          }
+        },
+        abort: abort
+      }
+    },
+    headObject: function(params) {
+      let md = {};
+      if (params['Key'] === 'dimensions.tif') {
+        md = { width: '100', height: '200'};
+      };
+      return {
+        promise: () => {
+          return {
+            Metadata: md
+          };
+        }
+      };
+    }
+  }
+});
+
+module.exports = {
+  S3: S3,
+  abort: abort,
+  end: end,
+  destroy: destroy
+};

--- a/tests/error.test.js
+++ b/tests/error.test.js
@@ -1,0 +1,62 @@
+const { errorHandler } = require('../src/error');
+const resource = require('./__mocks/mockResource');
+
+describe('errorHandler', () => {
+  const event = {};
+  const context = {};
+
+  const callback = (arg1, arg2) => {
+    return {
+      arg1: arg1,
+      arg2: arg2
+    }
+  };
+
+  beforeEach(() => {
+    const logSpy = jest.spyOn(console, 'log').mockImplementation((arg1, arg2) => {
+      return {
+        arg1: arg1,
+        arg2: arg2
+      }
+    });
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  })
+  it('has a statusCode', async () => {
+    const err = { statusCode: 404};
+    const resource = {};
+    const expected = {
+      arg1: null,
+      arg2: {
+        statusCode: 404,
+        headers: { 'Content-Type': 'text/plain' },
+        body: 'Not Found'
+      }
+    };
+    const result = await errorHandler(err, event, context, resource, callback);
+    expect(result).toEqual(expected);
+  });
+
+  it('is an instancof errorClass', async() => {
+    const err = new resource.errorClass('err');
+    const expected = {
+      arg1: null,
+      arg2: {
+        statusCode: 400,
+        headers: { 'Content-Type': 'text/plain' },
+        body: 'err'
+      }
+    };
+    const result = await errorHandler(err, event, context, resource, callback);
+    expect(result).toEqual(expected);
+  });
+
+  it('has a fallback error', async () => {
+    const err = new Error('I AM ERROR');
+    const expected = {
+      arg1: err,
+      arg2: null
+    };
+    const result = await errorHandler(err, event, context, resource, callback);
+    expect(result).toEqual(expected);
+  });
+})

--- a/tests/helpers.test.js
+++ b/tests/helpers.test.js
@@ -1,0 +1,107 @@
+const { eventPath, fileMissing, getUri, isBase64, isTooLarge, getRegion } = require('../src/helpers');
+
+describe('helper functions', () => {
+  describe('eventPath', () => {
+    it('does not includesStage', () => {
+      delete process.env.include_stage
+      const event = {
+        headers: { 'Host': 'host'},
+        path: '/path/'
+      };
+      expect(eventPath(event)).toEqual('/path');
+    });
+    it('includesStage', () => {
+      process.env.include_stage = 'true';
+      const event = {
+        headers: { 'Host': 'host'},
+        requestContext: {
+          stage: 'prod'
+        },
+        path: '/path/'
+      };
+      expect(eventPath(event)).toEqual('/prod/path');
+    });
+  });
+
+  describe('fileMissing', () => {
+    it('has a missing file', () => {
+      const event = {
+        path: 'http://path',
+      };
+      expect(fileMissing(event)).toEqual(true)
+    });
+    it('does not have a missing file', () => {
+      const event = {
+        path: 'http://path/file.json',
+      };
+      expect(fileMissing(event)).toEqual(false)
+    });
+  });
+
+  describe('getUri', () => {
+    beforeEach(() => {
+      delete process.env.include_stage
+    })
+    console.log = jest.fn()
+    it('has X-Forwarded headers', () => {
+      const event = {
+        headers: {
+          'X-Forwarded-Proto': 'https',
+          'X-Forwarded-Host': 'forward-host',
+          'Host': 'host'
+        },
+        path: '/path'
+      };
+      expect(getUri(event)).toEqual('https://forward-host/path');
+    });
+    it('does not have X-Forwarded headers', () => {
+      const event = {
+        headers: {
+          'Host': 'host'
+        },
+        path: '/path'
+      };
+      expect(getUri(event)).toEqual('http://host/path');
+    });
+  });
+
+  describe('isBase64', () => {
+    it('is base64', () => {
+      const result = {
+        contentType: 'image/jpeg'
+      };
+      expect(isBase64(result)).toEqual(true);
+    });
+    it('is not base64', () => {
+      const result = {
+        contentType: 'text/html'
+      };
+      expect(isBase64(result)).toEqual(false);
+    });
+  });
+
+  describe('isTooLarge', () => {
+    it('is > 6MB', () => {
+      const content = {
+        length: 6 * 1024 * 1024 + 1,
+      };
+      expect(isTooLarge(content)).toEqual(true);
+    });
+    it('is < 6MB', () => {
+      const content = {
+        length: 6 * 1024 * 1024 - 1,
+      };
+      expect(isTooLarge(content)).toEqual(false);
+    });
+  });
+
+  describe('getRegion', () => {
+    it('returns an AWS region', () => {
+      const context = {
+        invokedFunctionArn: 'arn:aws:lambda:us-west-2:123456789012:function:my-function'
+      };
+      expect(getRegion(context)).toEqual('us-west-2')
+    });
+  });
+
+})

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -1,0 +1,125 @@
+const IIIF = require('iiif-processor');
+const { handler } = require('../src/index');
+const helpers = require('../src/helpers');
+const errorHandler = require('../src/error');
+
+describe('index.handler', () => {
+  let callback;
+  const context = {};
+
+  beforeEach(() => {
+    jest.mock('../src/helpers');
+    helpers.getRegion = jest.fn().mockImplementation(() => {
+        return 'AWS REGION';
+    });
+
+    helpers.eventPath = jest.fn().mockImplementation(() => '[EVENT PATH]');
+    callback = (arg1, arg2) => {
+      return {
+        arg1: arg1,
+        arg2: arg2,
+      }
+    };
+    console.log = jest.fn();
+  });
+
+  it('responds to OPTIONS REQUEST', async () => {
+    const event = {
+      httpMethod: 'OPTIONS'
+    };
+
+    const expected = {
+      arg1: null,
+      arg2: { statusCode: 204, body: null }
+    };
+    const result = await handler(event, context, callback);
+    expect(result).toEqual(expected);
+  });
+
+  it('responds to INFO.JSON REQUEST', async () => {
+    helpers.fileMissing = jest.fn().mockImplementationOnce(() => true);
+
+    const event = {};
+
+    const expected = {
+      arg1: null,
+      arg2: { statusCode: 302, headers: { 'Location': '[EVENT PATH]/info.json' }, body: 'Redirecting to info.json' }
+    };
+    const result = await handler(event, context, callback);
+    expect(result).toEqual(expected);
+  })
+
+  // IMAGE REQUEST
+  describe('responds to IMAGE REQUEST', () => {
+    const body = '[CONTENT BODY]';
+    const event = {};
+    beforeEach(() => {
+      helpers.fileMissing = jest.fn().mockImplementationOnce(() => false);
+      helpers.getUri = jest.fn().mockImplementationOnce(() => '[IMAGE URI]');
+    });
+
+    it('works with base64 image.', async () => {
+      helpers.isBase64 = jest.fn().mockImplementationOnce(() => true);
+      helpers.isTooLarge = jest.fn().mockImplementationOnce(() => false);
+
+      IIIF.Processor = jest.fn().mockImplementationOnce(() => {
+        return {
+          execute: function() {
+            return { body: Buffer.from(body) };
+          }
+        };
+      });
+
+      const expected =  {
+        arg1: null,
+        arg2: {
+          statusCode: 200,
+          headers: { 'Content-Type': undefined, 'Access-Control-Allow-Origin': '*' },
+          isBase64Encoded: true,
+          body:  Buffer.from(body).toString('base64')
+        }
+      };
+      const result = await handler(event, context, callback);
+      expect(result).toEqual(expected);
+    });
+
+    it('works with nonbase64 image.', async () => {
+      IIIF.Processor = jest.fn().mockImplementationOnce(() => {
+        return {
+          execute: function() {
+            return { body: body }
+          }
+        };
+      });
+      helpers.isBase64 = jest.fn().mockImplementationOnce(() => false);
+      helpers.isTooLarge = jest.fn().mockImplementationOnce(() => false);
+
+      const expected = {
+        arg1: null,
+        arg2: {
+          statusCode: 200,
+          headers: { 'Content-Type': undefined, 'Access-Control-Allow-Origin': '*' },
+          isBase64Encoded: false,
+          body: body
+        }
+      };
+      const result = await handler(event, context, callback);
+      expect(result).toEqual(expected);
+    });
+
+    it('throws an error when file is too large.', async () => {
+      helpers.isBase64 = jest.fn().mockImplementationOnce(() => false);
+      helpers.isTooLarge = jest.fn().mockImplementationOnce(() => true);
+      errorHandler.errorHandler = jest.fn().mockImplementationOnce(() => null)
+      IIIF.Processor = jest.fn().mockImplementationOnce(() => {
+        return {
+          execute: function() {
+            return { body: body };
+          }
+        };
+      });
+      const result = await handler(event, context, callback);
+      expect(errorHandler.errorHandler).toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/resolvers.test.js
+++ b/tests/resolvers.test.js
@@ -1,0 +1,37 @@
+const AWS = require('aws-sdk');
+const { streamResolver, dimensionResolver } = require('../src/resolvers');
+const AWSMockS3 = require('./__mocks/mockS3');
+
+describe('resolvers', () => {
+  beforeEach(() => {
+    AWS.S3 = AWSMockS3.S3;
+  })
+
+  describe('streamResolver', () => {
+    it('returns a stream and cleans up', async () => {
+      const callback = jest.fn((stream) => {});
+      const result = await streamResolver('id', callback);
+      expect(callback).toHaveBeenCalled();
+      expect(AWSMockS3.end).toHaveBeenCalled();
+      expect(AWSMockS3.destroy).toHaveBeenCalled();
+      expect(AWSMockS3.abort).toHaveBeenCalled();
+    });
+  });
+
+  describe('dimensionResolver', () => {
+    it('has metadata dimensions', async () => {
+      const expected = {
+        width: 100,
+        height: 200
+      };
+      const result = await dimensionResolver('dimensions');
+      expect(result).toEqual(expected)
+    });
+
+    it('does not have metadata dimensions', async () => {
+      const expected = null;
+      const result = await dimensionResolver('no-dimenstions');
+      expect(result).toEqual(expected)
+    });
+  });
+});


### PR DESCRIPTION
This appears to be consistently more reliable when running a script to pull images down locally.
Using this script: [downloadImages.js](https://github.com/ndlib/marble-website-starter/blob/master/scripts/gatsby-source-iiif/downloadImages.js).

* Rewrite `class` based code as a function
* Remove `middy` dependency
* Rewrite IIIF resolver following example here: https://github.com/nulib/node-iiif#amazon-s3-bucket-source
* Bump package major version
* Added unit tests with coverage report

![Screen Shot 2020-09-25 at 9 23 06 AM](https://user-images.githubusercontent.com/416559/94272217-c2253780-ff10-11ea-93b8-b7e75844b7eb.png)
