### PR TITLE
MARBLE-1186 Fix error response codes 

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -12,7 +12,7 @@ const fileMissing = (event) => {
 
 const getUri = (event) => {
   const scheme = event.headers['X-Forwarded-Proto'] || 'http';
-  const host = event.headers['X-Forwarded-Host'] || event.headers['Host'];
+  const host = event.headers['X-Forwarded-Host'] || event.headers.Host;
   const uri = `${scheme}://${host}${eventPath(event)}`;
   return uri;
 };
@@ -21,7 +21,7 @@ const includeStage = (event) => {
   if ('include_stage' in process.env) {
     return ['true', 'yes'].indexOf(process.env.include_stage.toLowerCase()) > -1;
   } else {
-    const host = event.headers['Host'];
+    const host = event.headers.Host;
     return host.match(/\.execute-api\.\w+?-\w+?-\d+?\.amazonaws\.com$/);
   }
 };
@@ -32,10 +32,10 @@ const isBase64 = (result) => {
 
 const isTooLarge = (content) => {
   return content.length > 6 * 1024 * 1024;
-}
+};
 const getRegion = (context) => {
   return context.invokedFunctionArn.match(/^arn:aws:lambda:(\w+-\w+-\d+):/)[1];
-}
+};
 
 module.exports = {
   eventPath: eventPath,
@@ -44,5 +44,5 @@ module.exports = {
   includeStage: includeStage,
   isBase64: isBase64,
   isTooLarge: isTooLarge,
-  getRegion: getRegion,
+  getRegion: getRegion
 };

--- a/src/index.js
+++ b/src/index.js
@@ -25,14 +25,16 @@ const handleRequestFunc = async (event, context, callback) => {
     return callback(null, { statusCode: 302, headers: { Location: location }, body: 'Redirecting to info.json' });
   } else {
     // IMAGE REQUEST
-    const uri = getUri(event);
-    const resource = new IIIF.Processor(
-      uri,
-      streamResolver,
-      dimensionResolver
-    );
-    const result = await resource.execute();
+    let resource;
     try {
+      const uri = getUri(event);
+      resource = new IIIF.Processor(
+        uri,
+        streamResolver,
+        dimensionResolver
+      );
+      const result = await resource.execute();
+
       const base64 = isBase64(result);
       const content = base64 ? result.body.toString('base64') : result.body;
       const response = {


### PR DESCRIPTION
* Call to IIIF.Processor was not inside a `try` block and was throwing an error resulting in the server not catching and returning a 502. 
* Fixed linting on helpers.js