### PR TITLE
update packages to new minimum version to support webp

### DIFF
--- a/dependencies/nodejs/package.json
+++ b/dependencies/nodejs/package.json
@@ -6,6 +6,6 @@
   "license": "Apache-2.0",
   "dependencies": {
     "aws-sdk": "^2.368.0",
-    "iiif-processor": "ndlib/node-iiif#master"
+    "iiif-processor": "~0.3.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-standard": "^4.0.1",
-    "iiif-processor": "ndlib/node-iiif#master",
+    "iiif-processor": "~0.3.4",
     "jest": "^26.4.2"
   },
   "jest": {

--- a/src/package.json
+++ b/src/package.json
@@ -7,6 +7,6 @@
   "dependencies": {},
   "devDependencies": {
     "aws-sdk": "^2.368.0",
-    "iiif-processor": "ndlib/node-iiif#master"
+    "iiif-processor": "~0.3.4"
   }
 }


### PR DESCRIPTION
If Northwester takes our changes to add `webp` to https://github.com/nulib/node-iiif/pull/6 this is the version of `iiif-processor` we'd likely want to point to.

**Note: Travis will likely fail because it's currently pointing to a non-existent package version.**